### PR TITLE
fix-bug

### DIFF
--- a/test.py
+++ b/test.py
@@ -43,9 +43,9 @@ def main(_argv):
         img = cv2.imread(FLAGS.img_path)
         img = cv2.resize(img, (cfg['input_size'], cfg['input_size']))
         img = img.astype(np.float32) / 255.
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         if len(img.shape) == 3:
             img = np.expand_dims(img, 0)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         embeds = l2_norm(model(img))
         np.save('./output_embeds.npy', embeds)
     else:


### PR DESCRIPTION
when run below command 
`python test.py --cfg_path="./configs/arc_res50.yaml" --img_path="./data/BruceLee.jpg"`
get error : `The first dimension of paddings must be the rank of inputs[4,2] [1,112,3] [Op:Pad]`
to solve this error , i change position of convert color in test.py to before of expand dims of image